### PR TITLE
Remove utc reference from module

### DIFF
--- a/winfiletime/__init__.py
+++ b/winfiletime/__init__.py
@@ -1,3 +1,3 @@
-from .filetime import EPOCH_AS_FILETIME, from_datetime, to_datetime, utc
+from .filetime import EPOCH_AS_FILETIME, from_datetime, to_datetime
 
-__all__ = ["EPOCH_AS_FILETIME", "from_datetime", "to_datetime", "utc"]
+__all__ = ["EPOCH_AS_FILETIME", "from_datetime", "to_datetime"]


### PR DESCRIPTION
>>> import winfiletime
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/__init__.py", line 1, in <module>
    from .filetime import EPOCH_AS_FILETIME, from_datetime, to_datetime, utc
ImportError: cannot import name 'utc' from 'winfiletime.filetime' (/py38/lib/python3.8/site-packages/winfiletime/filetime.py)
>>> import datetime
>>> import winfiletime
